### PR TITLE
Migrate Core and Persistence projects to .NET Standard 2.0

### DIFF
--- a/Core/Caretaker.cs
+++ b/Core/Caretaker.cs
@@ -1,4 +1,6 @@
-﻿namespace MachineStateManager.Core
+﻿using System;
+
+namespace MachineStateManager.Core
 {
     internal class Caretaker<TOriginator, TMemento> : IDisposable
         where TOriginator : IOriginator<TMemento>
@@ -16,8 +18,18 @@
 
         protected Caretaker(TOriginator originator, TMemento memento)
         {
-            Originator = originator ?? throw new ArgumentNullException(nameof(originator));
-            Memento = memento ?? throw new ArgumentNullException(nameof(memento));
+            if (originator == null)
+            {
+                throw new ArgumentNullException(nameof(originator));
+            }
+
+            if (memento == null)
+            {
+                throw new ArgumentNullException(nameof(memento));
+            }
+
+            Originator = originator;
+            Memento = memento;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/Core/Environment/EnvironmentVariableMemento.cs
+++ b/Core/Environment/EnvironmentVariableMemento.cs
@@ -2,9 +2,9 @@
 {
     internal class EnvironmentVariableMemento : IMemento
     {
-        public string? Value { get; }
+        public string Value { get; }
 
-        public EnvironmentVariableMemento(string? value)
+        public EnvironmentVariableMemento(string value)
         {
             Value = value;
         }

--- a/Core/Environment/EnvironmentVariableOriginator.cs
+++ b/Core/Environment/EnvironmentVariableOriginator.cs
@@ -1,4 +1,6 @@
-﻿namespace MachineStateManager.Core.Environment
+﻿using System;
+
+namespace MachineStateManager.Core.Environment
 {
     internal class EnvironmentVariableOriginator : IOriginator<EnvironmentVariableMemento>
     {

--- a/Core/FileSystem/Caching/LocalBlobStore.cs
+++ b/Core/FileSystem/Caching/LocalBlobStore.cs
@@ -1,4 +1,7 @@
-﻿namespace MachineStateManager.Core.FileSystem.Caching
+﻿using System;
+using System.IO;
+
+namespace MachineStateManager.Core.FileSystem.Caching
 {
     internal class LocalBlobStore : IBlobStore
     {

--- a/Core/FileSystem/DirectoryOriginator.cs
+++ b/Core/FileSystem/DirectoryOriginator.cs
@@ -1,4 +1,7 @@
-﻿namespace MachineStateManager.Core.FileSystem
+﻿using System;
+using System.IO;
+
+namespace MachineStateManager.Core.FileSystem
 {
     internal class DirectoryOriginator : IOriginator<DirectoryMemento>
     {

--- a/Core/FileSystem/FileMemento.cs
+++ b/Core/FileSystem/FileMemento.cs
@@ -2,9 +2,9 @@
 {
     internal class FileMemento : IMemento
     {
-        public string? Hash { get; }
+        public string Hash { get; }
 
-        public FileMemento(string? hash)
+        public FileMemento(string hash)
         {
             Hash = hash;
         }

--- a/Core/FileSystem/FileOriginator.cs
+++ b/Core/FileSystem/FileOriginator.cs
@@ -1,4 +1,7 @@
-﻿namespace MachineStateManager.Core.FileSystem
+﻿using System;
+using System.IO;
+
+namespace MachineStateManager.Core.FileSystem
 {
     internal class FileOriginator : IOriginator<FileMemento>
     {

--- a/Core/MachineStateManager.Core.csproj
+++ b/Core/MachineStateManager.Core.csproj
@@ -1,15 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>MachineStateManager.Persistence</_Parameter1>
     </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Core/MachineStateManager.cs
+++ b/Core/MachineStateManager.cs
@@ -4,7 +4,9 @@ using MachineStateManager.Core.FileSystem;
 using MachineStateManager.Core.FileSystem.Caching;
 using MachineStateManager.Core.Registry;
 using Microsoft.Win32;
-using System.Runtime.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace MachineStateManager
 {
@@ -58,7 +60,6 @@ namespace MachineStateManager
             return caretaker;
         }
 
-        [SupportedOSPlatform("windows")]
         public virtual IDisposable SnapshotRegistryKey(RegistryHive hive, RegistryView view, string subKey)
         {
             var originator = new RegistryKeyOriginator(hive, view, subKey);
@@ -67,7 +68,6 @@ namespace MachineStateManager
             return caretaker;
         }
 
-        [SupportedOSPlatform("windows")]
         public virtual IDisposable SnapshotRegistryValue(RegistryHive hive, RegistryView view, string subKey, string name)
         {
             var originator = new RegistryValueOriginator(hive, view, subKey, name);

--- a/Core/Registry/RegistryKeyMemento.cs
+++ b/Core/Registry/RegistryKeyMemento.cs
@@ -1,8 +1,5 @@
-﻿using System.Runtime.Versioning;
-
-namespace MachineStateManager.Core.Registry
+﻿namespace MachineStateManager.Core.Registry
 {
-    [SupportedOSPlatform("windows")]
     internal class RegistryKeyMemento : IMemento
     {
         public bool Exists { get; }

--- a/Core/Registry/RegistryKeyOriginator.cs
+++ b/Core/Registry/RegistryKeyOriginator.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Win32;
-using System.Runtime.Versioning;
 
 namespace MachineStateManager.Core.Registry
 {
-    [SupportedOSPlatform("windows")]
     internal class RegistryKeyOriginator : IOriginator<RegistryKeyMemento>
     {
         public RegistryHive Hive { get; }

--- a/Core/Registry/RegistryValueMemento.cs
+++ b/Core/Registry/RegistryValueMemento.cs
@@ -4,11 +4,11 @@ namespace MachineStateManager.Core.Registry
 {
     internal class RegistryValueMemento : IMemento
     {
-        public object? Value { get; }
+        public object Value { get; }
 
         public RegistryValueKind Kind { get; }
 
-        public RegistryValueMemento(object? value, RegistryValueKind kind)
+        public RegistryValueMemento(object value, RegistryValueKind kind)
         {
             Value = value;
             Kind = kind;

--- a/Core/Registry/RegistryValueOriginator.cs
+++ b/Core/Registry/RegistryValueOriginator.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Win32;
-using System.Runtime.Versioning;
 
 namespace MachineStateManager.Core.Registry
 {
-    [SupportedOSPlatform("windows")]
     internal class RegistryValueOriginator : IOriginator<RegistryValueMemento>
     {
         public RegistryHive Hive { get; }
@@ -12,7 +10,7 @@ namespace MachineStateManager.Core.Registry
 
         public string SubKey { get; }
 
-        public string? Name { get; }
+        public string Name { get; }
 
         public RegistryValueOriginator(RegistryHive hive, RegistryView view, string subKey, string name)
         {

--- a/Persistence/Environment/PersistentEnvironmentVariableCaretaker.cs
+++ b/Persistence/Environment/PersistentEnvironmentVariableCaretaker.cs
@@ -1,6 +1,9 @@
 ﻿using LiteDB;
 using MachineStateManager.Core.Environment;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace MachineStateManager.Persistence.Environment
 {
@@ -27,7 +30,7 @@ namespace MachineStateManager.Persistence.Environment
                 {
                     var originator = new EnvironmentVariableOriginator(
                         bson[nameof(Originator)][nameof(EnvironmentVariableOriginator.Name)].AsString,
-                        Enum.Parse<EnvironmentVariableTarget>(bson[nameof(Originator)][nameof(EnvironmentVariableOriginator.Target)].AsString));
+                        (EnvironmentVariableTarget)Enum.Parse(typeof(EnvironmentVariableTarget), bson[nameof(Originator)][nameof(EnvironmentVariableOriginator.Target)].AsString));
                     var memento = new EnvironmentVariableMemento(
                         bson[nameof(Memento)][nameof(EnvironmentVariableMemento.Value)].AsString);
                     return new PersistentEnvironmentVariableCaretaker(bson["_id"].AsString, bson[nameof(ProcessID)].AsInt32, bson[nameof(ProcessStartTime)].AsDateTime, originator, memento);
@@ -65,9 +68,9 @@ namespace MachineStateManager.Persistence.Environment
                 throw new ArgumentNullException(nameof(originator));
             }
 
-            var id = string.Join('\\', originator.Target, originator.Name);
+            var id = string.Join("\\", originator.Target, originator.Name);
 
-            if (OperatingSystem.IsWindows())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 id = id.ToLower();
             }

--- a/Persistence/FileSystem/Caching/LiteDBBlobStore.cs
+++ b/Persistence/FileSystem/Caching/LiteDBBlobStore.cs
@@ -1,4 +1,6 @@
 ﻿using MachineStateManager.Core.FileSystem;
+using System;
+using System.IO;
 using System.Security.Cryptography;
 
 namespace MachineStateManager.Persistence.FileSystem.Caching
@@ -7,40 +9,48 @@ namespace MachineStateManager.Persistence.FileSystem.Caching
     {
         public void DownloadFile(string id, string destinationPath)
         {
-            using var database = PersistentFileCaretaker.GetDatabase();
-            var fileStorage = database.FileStorage;
-            var blobFile = fileStorage.FindById(id);
-            if (blobFile == null)
+            using (var database = PersistentFileCaretaker.GetDatabase())
             {
-                throw new FileNotFoundException();
+                var fileStorage = database.FileStorage;
+                var blobFile = fileStorage.FindById(id);
+                if (blobFile == null)
+                {
+                    throw new FileNotFoundException();
+                }
+
+                var destinationFile = new FileInfo(destinationPath);
+                using (var destinationStream = destinationFile.Open(FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
+                {
+                    destinationStream.SetLength(0); // Delete existing file.
+
+                    blobFile.CopyTo(destinationStream);
+                }
             }
-
-            var destinationFile = new FileInfo(destinationPath);
-            using var destinationStream = destinationFile.Open(FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
-            destinationStream.SetLength(0); // Delete existing file.
-
-            blobFile.CopyTo(destinationStream);
         }
 
         public string UploadFile(string sourcePath)
         {
-            using var database = PersistentFileCaretaker.GetDatabase();
-            var fileStorage = database.FileStorage;
-            var sourceFile = new FileInfo(sourcePath);
-            if (!sourceFile.Exists)
+            using (var database = PersistentFileCaretaker.GetDatabase())
             {
-                throw new FileNotFoundException();
-            }
-            using var sourceStream = sourceFile.Open(FileMode.Open, FileAccess.Read, FileShare.Read);
+                var fileStorage = database.FileStorage;
+                var sourceFile = new FileInfo(sourcePath);
+                if (!sourceFile.Exists)
+                {
+                    throw new FileNotFoundException();
+                }
+                using (var sourceStream = sourceFile.Open(FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
 
-            var id = ComputeFileHash(sourceStream);
-            var blobFile = fileStorage.FindById(id);
-            if (blobFile == null)
-            {
-                fileStorage.Upload(id, id, sourceStream);
-            }
+                    var id = ComputeFileHash(sourceStream);
+                    var blobFile = fileStorage.FindById(id);
+                    if (blobFile == null)
+                    {
+                        fileStorage.Upload(id, id, sourceStream);
+                    }
 
-            return id;
+                    return id;
+                }
+            }
         }
 
         private static string ComputeFileHash(FileStream fileStream)
@@ -49,13 +59,15 @@ namespace MachineStateManager.Persistence.FileSystem.Caching
 
             fileStream.Position = 0;
 
-            using var md5 = MD5.Create();
+            using (var md5 = MD5.Create())
+            {
 
-            var hash = md5.ComputeHash(fileStream);
+                var hash = md5.ComputeHash(fileStream);
 
-            fileStream.Position = previousPosition;
+                fileStream.Position = previousPosition;
 
-            return Convert.ToHexString(hash);
+                return BitConverter.ToString(hash).Replace("-", string.Empty);
+            }
         }
     }
 }

--- a/Persistence/FileSystem/PersistentDirectoryCaretaker.cs
+++ b/Persistence/FileSystem/PersistentDirectoryCaretaker.cs
@@ -1,6 +1,9 @@
 ﻿using LiteDB;
 using MachineStateManager.Core.FileSystem;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace MachineStateManager.Persistence.FileSystem
 {
@@ -61,7 +64,7 @@ namespace MachineStateManager.Persistence.FileSystem
 
             var id = originator.Path;
 
-            if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 id = id.ToLower();
             }

--- a/Persistence/FileSystem/PersistentFileCaretaker.cs
+++ b/Persistence/FileSystem/PersistentFileCaretaker.cs
@@ -1,7 +1,11 @@
 ﻿using LiteDB;
 using MachineStateManager.Core.FileSystem;
 using MachineStateManager.Persistence.FileSystem.Caching;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace MachineStateManager.Persistence.FileSystem
 {
@@ -63,13 +67,15 @@ namespace MachineStateManager.Persistence.FileSystem
             {
                 if (disposing)
                 {
-                    using var database = GetDatabase();
-                    var collection = database.GetCollection<PersistentFileCaretaker>();
-
-                    if (!(collection.Find(c => c.Memento.Hash == Memento.Hash).Any()))
+                    using (var database = GetDatabase())
                     {
-                        var fileStorage = database.FileStorage;
-                        fileStorage.Delete(Memento.Hash);
+                        var collection = database.GetCollection<PersistentFileCaretaker>();
+
+                        if (!(collection.Find(c => c.Memento.Hash == Memento.Hash).Any()))
+                        {
+                            var fileStorage = database.FileStorage;
+                            fileStorage.Delete(Memento.Hash);
+                        }
                     }
                 }
 
@@ -88,7 +94,7 @@ namespace MachineStateManager.Persistence.FileSystem
 
             var id = originator.Path;
 
-            if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 id = id.ToLower();
             }

--- a/Persistence/MachineStateManager.Persistence.csproj
+++ b/Persistence/MachineStateManager.Persistence.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LiteDB" Version="5.0.11" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Persistence/PersistentMachineStateManager.cs
+++ b/Persistence/PersistentMachineStateManager.cs
@@ -3,8 +3,11 @@ using MachineStateManager.Persistence.FileSystem;
 using MachineStateManager.Persistence.FileSystem.Caching;
 using MachineStateManager.Persistence.Registry;
 using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
 namespace MachineStateManager.Persistence
@@ -49,7 +52,6 @@ namespace MachineStateManager.Persistence
             return caretaker;
         }
 
-        [SupportedOSPlatform("windows")]
         public override IDisposable SnapshotRegistryKey(RegistryHive hive, RegistryView view, string subKey)
         {
             var caretaker = new PersistentRegistryKeyCaretaker(hive, view, subKey);
@@ -57,7 +59,6 @@ namespace MachineStateManager.Persistence
             return caretaker;
         }
 
-        [SupportedOSPlatform("windows")]
         public override IDisposable SnapshotRegistryValue(RegistryHive hive, RegistryView view, string subKey, string name)
         {
             var caretaker = new PersistentRegistryValueCaretaker(hive, view, subKey, name);
@@ -86,7 +87,7 @@ namespace MachineStateManager.Persistence
             abandonedCaretakers.AddRange(PersistentEnvironmentVariableCaretaker.GetAbandonedCaretakers(processes));
             abandonedCaretakers.AddRange(PersistentDirectoryCaretaker.GetAbandonedCaretakers(processes));
             abandonedCaretakers.AddRange(PersistentFileCaretaker.GetAbandonedCaretakers(processes));
-            if (OperatingSystem.IsWindows())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 abandonedCaretakers.AddRange(PersistentRegistryKeyCaretaker.GetAbandonedCaretakers(processes));
                 abandonedCaretakers.AddRange(PersistentRegistryValueCaretaker.GetAbandonedCaretakers(processes));

--- a/Persistence/Registry/PersistentRegistryKeyCaretaker.cs
+++ b/Persistence/Registry/PersistentRegistryKeyCaretaker.cs
@@ -1,12 +1,12 @@
 ﻿using LiteDB;
 using MachineStateManager.Core.Registry;
 using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.Versioning;
 
 namespace MachineStateManager.Persistence.Registry
 {
-    [SupportedOSPlatform("windows")]
     internal class PersistentRegistryKeyCaretaker : PersistentCaretaker<RegistryKeyOriginator, RegistryKeyMemento>
     {
         static PersistentRegistryKeyCaretaker()
@@ -29,8 +29,8 @@ namespace MachineStateManager.Persistence.Registry
                 deserialize: (bson) =>
                 {
                     var originator = new RegistryKeyOriginator(
-                        Enum.Parse<RegistryHive>(bson[nameof(Originator)][nameof(RegistryKeyOriginator.Hive)].AsString),
-                        Enum.Parse<RegistryView>(bson[nameof(Originator)][nameof(RegistryKeyOriginator.View)].AsString),
+                        (RegistryHive)Enum.Parse(typeof(RegistryHive), bson[nameof(Originator)][nameof(RegistryKeyOriginator.Hive)].AsString),
+                        (RegistryView)Enum.Parse(typeof(RegistryView), bson[nameof(Originator)][nameof(RegistryKeyOriginator.View)].AsString),
                         bson[nameof(Originator)][nameof(RegistryKeyOriginator.SubKey)].AsString);
                     var memento = new RegistryKeyMemento(
                         bson[nameof(Memento)][nameof(RegistryKeyMemento.Exists)].AsBoolean);
@@ -64,7 +64,7 @@ namespace MachineStateManager.Persistence.Registry
                 throw new ArgumentNullException(nameof(originator));
             }
 
-            return string.Join('\\', originator.Hive, originator.View, originator.SubKey).ToLower();
+            return string.Join("\\", originator.Hive, originator.View, originator.SubKey).ToLower();
         }
     }
 }

--- a/Persistence/Registry/PersistentRegistryValueCaretaker.cs
+++ b/Persistence/Registry/PersistentRegistryValueCaretaker.cs
@@ -1,12 +1,13 @@
 ﻿using LiteDB;
 using MachineStateManager.Core.Registry;
 using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Versioning;
 
 namespace MachineStateManager.Persistence.Registry
 {
-    [SupportedOSPlatform("windows")]
     internal class PersistentRegistryValueCaretaker : PersistentCaretaker<RegistryValueOriginator, RegistryValueMemento>
     {
         static PersistentRegistryValueCaretaker()
@@ -29,13 +30,13 @@ namespace MachineStateManager.Persistence.Registry
                 deserialize: (bson) =>
                 {
                     var originator = new RegistryValueOriginator(
-                        Enum.Parse<RegistryHive>(bson[nameof(Originator)][nameof(RegistryValueOriginator.Hive)].AsString),
-                        Enum.Parse<RegistryView>(bson[nameof(Originator)][nameof(RegistryValueOriginator.View)].AsString),
+                        (RegistryHive)Enum.Parse(typeof(RegistryHive), bson[nameof(Originator)][nameof(RegistryValueOriginator.Hive)].AsString),
+                        (RegistryView)Enum.Parse(typeof(RegistryView), bson[nameof(Originator)][nameof(RegistryValueOriginator.View)].AsString),
                         bson[nameof(Originator)][nameof(RegistryValueOriginator.SubKey)].AsString,
                         bson[nameof(Originator)][nameof(RegistryValueOriginator.Name)].AsString);
                     var memento = new RegistryValueMemento(
                         bson[nameof(Memento)][nameof(RegistryValueMemento.Value)],
-                        Enum.Parse<RegistryValueKind>(bson[nameof(Memento)][nameof(RegistryValueMemento.Kind)].AsString));
+                        (RegistryValueKind)Enum.Parse(typeof(RegistryValueKind), bson[nameof(Memento)][nameof(RegistryValueMemento.Kind)].AsString));
                     return new PersistentRegistryValueCaretaker(bson["_id"].AsString, bson[nameof(ProcessID)].AsInt32, bson[nameof(ProcessStartTime)].AsDateTime, originator, memento);
                 }
             );
@@ -66,7 +67,7 @@ namespace MachineStateManager.Persistence.Registry
                 throw new ArgumentNullException(nameof(originator));
             }
 
-            return string.Join('\\', originator.Hive, originator.View, originator.SubKey, originator.Name ?? "(Default)").ToLower();
+            return string.Join("\\", originator.Hive, originator.View, originator.SubKey, originator.Name ?? "(Default)").ToLower();
         }
     }
 }


### PR DESCRIPTION
Migrating `MachineStateManager` to .NET Standard 2.0 so that it can be used by a wider variety of projects.