### PR TITLE
RegistryKeyOriginator.SetState should recursively delete

### DIFF
--- a/MachineStateManager.Persistence.Tests/EnvironmentTests.cs
+++ b/MachineStateManager.Persistence.Tests/EnvironmentTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace bradselw.MachineStateManager.Persistence.Tests
 {
     [TestClass]

--- a/MachineStateManager.Persistence.Tests/FileSystemTests.cs
+++ b/MachineStateManager.Persistence.Tests/FileSystemTests.cs
@@ -1,4 +1,7 @@
-﻿namespace bradselw.MachineStateManager.Persistence.Tests
+﻿using System;
+using System.IO;
+
+namespace bradselw.MachineStateManager.Persistence.Tests
 {
     [TestClass]
     public class FileSystemTests

--- a/MachineStateManager.Persistence.Tests/MachineStateManager.Persistence.Tests.csproj
+++ b/MachineStateManager.Persistence.Tests/MachineStateManager.Persistence.Tests.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/MachineStateManager.Persistence.Tests/MachineStateManagerTests.cs
+++ b/MachineStateManager.Persistence.Tests/MachineStateManagerTests.cs
@@ -1,4 +1,8 @@
-﻿namespace bradselw.MachineStateManager.Persistence.Tests
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace bradselw.MachineStateManager.Persistence.Tests
 {
     [TestClass]
     public class MachineStateManagerTests

--- a/MachineStateManager.Persistence.Tests/RegistryTests.cs
+++ b/MachineStateManager.Persistence.Tests/RegistryTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Win32;
+using System;
+using System.IO;
 using System.Runtime.Versioning;
 
 namespace bradselw.MachineStateManager.Persistence.Tests
@@ -59,7 +61,7 @@ namespace bradselw.MachineStateManager.Persistence.Tests
                 Assert.AreEqual(null, regKey.GetValue(name));
             }
 
-            Assert.AreEqual("bar", (string?)regKey.GetValue(name));
+            Assert.AreEqual("bar", (string)regKey.GetValue(name));
         }
 
         private static void RecursiveDeleteRegistryKey(RegistryHive hive, RegistryView view, string subKey)

--- a/MachineStateManager.Tests/MachineStateManager.Tests.csproj
+++ b/MachineStateManager.Tests/MachineStateManager.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/MachineStateManager.Tests/RegistryTests.cs
+++ b/MachineStateManager.Tests/RegistryTests.cs
@@ -61,7 +61,7 @@ namespace bradselw.MachineStateManager.Tests
                 Assert.AreEqual(null, regKey.GetValue(name));
             }
 
-            Assert.AreEqual("bar", (string?)regKey.GetValue(name));
+            Assert.AreEqual("bar", (string)regKey.GetValue(name));
         }
 
         private static void RecursiveDeleteRegistryKey(RegistryHive hive, RegistryView view, string subKey)

--- a/MachineStateManager/MachineStateManager.csproj
+++ b/MachineStateManager/MachineStateManager.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="bradselw.SystemResources.Environment" Version="1.0.2" />
     <PackageReference Include="bradselw.SystemResources.FileSystem" Version="1.0.4" />
-    <PackageReference Include="bradselw.SystemResources.Registry" Version="1.0.2" />
+    <PackageReference Include="bradselw.SystemResources.Registry" Version="1.0.5" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 

--- a/MachineStateManager/Registry/RegistryKeyOriginator.cs
+++ b/MachineStateManager/Registry/RegistryKeyOriginator.cs
@@ -33,7 +33,7 @@ namespace bradselw.MachineStateManager.Registry
             {
                 if (!memento.Exists)
                 {
-                    Registry.DeleteRegistryKey(Hive, View, SubKey);
+                    Registry.DeleteRegistryKey(Hive, View, SubKey, recursive: true);
                 }
             }
             else


### PR DESCRIPTION
When restoring a `RegistryKeyMemento`, `RegistryKeyOriginator.SetState` should recursively delete the subkey, to completely eradicate it from the registry, thus restoring the state of the previously nonexistent key.