### PR TITLE
Throw custom exception when resource is locked

### DIFF
--- a/MachineStateManager.Persistence/PersistentCaretaker.cs
+++ b/MachineStateManager.Persistence/PersistentCaretaker.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LiteDB;
+using System;
 using System.Diagnostics;
 
 namespace bradselw.MachineStateManager.Persistence
@@ -38,9 +39,15 @@ namespace bradselw.MachineStateManager.Persistence
                         database.Commit();
                         persisted = true;
                     }
-                    catch
+                    catch (Exception ex)
                     {
                         database.Rollback();
+
+                        if (ex is LiteException liteEx && liteEx.ErrorCode == LiteException.INDEX_DUPLICATE_KEY)
+                        {
+                            throw new ResourceLockedException($"The resource '{ID}' is locked by another instance.", liteEx);
+                        }
+
                         throw;
                     }
                 }

--- a/MachineStateManager.Persistence/ResourceLockedException.cs
+++ b/MachineStateManager.Persistence/ResourceLockedException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace bradselw.MachineStateManager.Persistence
+{
+    public class ResourceLockedException : Exception
+    {
+        public ResourceLockedException()
+        {
+        }
+
+        public ResourceLockedException(string message)
+            : base(message)
+        {
+        }
+
+        public ResourceLockedException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}


### PR DESCRIPTION
When a MSM tries to get a caretaker for a machine resource that has already had a caretaker created for it by another MSM, a `LiteException` gets thrown stating that it "cannot insert duplicate key". This is confusing and not actionable for the user.

This change creates a new exception type called `ResourceLockedException` that gets thrown when trying to create a caretaker for a resource that is already being tracked by another MSM.