### PR TITLE
Add static member that sets database location

### DIFF
--- a/MachineStateManager.Persistence.Tests/EnvironmentTests.cs
+++ b/MachineStateManager.Persistence.Tests/EnvironmentTests.cs
@@ -10,17 +10,17 @@ namespace bradselw.MachineStateManager.Persistence.Tests
         {
             var machineStateManager = new PersistentMachineStateManager();
             var name = "foo";
-            var previousValue = System.Environment.GetEnvironmentVariable(name);//"bar";//
+            var previousValue = global::System.Environment.GetEnvironmentVariable(name);//"bar";//
             //System.Environment.SetEnvironmentVariable(name, previousValue);
 
             using (machineStateManager.SnapshotEnvironmentVariable(name))
             {
                 var newValue = Guid.NewGuid().ToString();
-                System.Environment.SetEnvironmentVariable(name, newValue);
-                Assert.AreEqual(newValue, System.Environment.GetEnvironmentVariable(name));
+                global::System.Environment.SetEnvironmentVariable(name, newValue);
+                Assert.AreEqual(newValue, global::System.Environment.GetEnvironmentVariable(name));
             }
 
-            Assert.AreEqual(previousValue, System.Environment.GetEnvironmentVariable(name));
+            Assert.AreEqual(previousValue, global::System.Environment.GetEnvironmentVariable(name));
         }
 
         [TestMethod]
@@ -29,16 +29,16 @@ namespace bradselw.MachineStateManager.Persistence.Tests
             var machineStateManager1 = new PersistentMachineStateManager();
             var machineStateManager2 = new PersistentMachineStateManager();
             var name = "foo";
-            var previousValue = System.Environment.GetEnvironmentVariable(name);
+            var previousValue = global::System.Environment.GetEnvironmentVariable(name);
 
             using (machineStateManager1.SnapshotEnvironmentVariable(name))
             {
                 var newValue = Guid.NewGuid().ToString();
-                System.Environment.SetEnvironmentVariable(name, newValue);
-                Assert.AreEqual(newValue, System.Environment.GetEnvironmentVariable(name));
+                global::System.Environment.SetEnvironmentVariable(name, newValue);
+                Assert.AreEqual(newValue, global::System.Environment.GetEnvironmentVariable(name));
             }
 
-            Assert.AreEqual(previousValue, System.Environment.GetEnvironmentVariable(name));
+            Assert.AreEqual(previousValue, global::System.Environment.GetEnvironmentVariable(name));
         }
     }
 }

--- a/MachineStateManager.Persistence.Tests/MachineStateManagerTests.cs
+++ b/MachineStateManager.Persistence.Tests/MachineStateManagerTests.cs
@@ -10,7 +10,7 @@ namespace bradselw.MachineStateManager.Persistence.Tests
         [TestMethod]
         public void RestoreAbandonedCaretakers()
         {
-            PersistentMachineStateManager.RestoreAbandonedCaretakers();
+            PersistentMachineStateManager.RestoreAbandonedSnapshots();
         }
 
         [TestMethod]
@@ -18,18 +18,18 @@ namespace bradselw.MachineStateManager.Persistence.Tests
         {
             var machineStateManager = new PersistentMachineStateManager();
             var name = "foo";
-            var previousValue = System.Environment.GetEnvironmentVariable(name);//"bar";//
+            var previousValue = global::System.Environment.GetEnvironmentVariable(name);//"bar";//
             //System.Environment.SetEnvironmentVariable(name, previousValue);
 
             using (machineStateManager.SnapshotEnvironmentVariable(name))
             {
                 var newValue = Guid.NewGuid().ToString();
-                System.Environment.SetEnvironmentVariable(name, newValue);
-                PersistentMachineStateManager.RestoreAbandonedCaretakers();
-                Assert.AreEqual(newValue, System.Environment.GetEnvironmentVariable(name));
+                global::System.Environment.SetEnvironmentVariable(name, newValue);
+                PersistentMachineStateManager.RestoreAbandonedSnapshots();
+                Assert.AreEqual(newValue, global::System.Environment.GetEnvironmentVariable(name));
             }
 
-            Assert.AreEqual(previousValue, System.Environment.GetEnvironmentVariable(name));
+            Assert.AreEqual(previousValue, global::System.Environment.GetEnvironmentVariable(name));
         }
 
         [TestMethod]
@@ -46,10 +46,10 @@ namespace bradselw.MachineStateManager.Persistence.Tests
                     var name = Guid.NewGuid().ToString();
                     using (machineStateManager.SnapshotEnvironmentVariable(name))
                     {
-                        System.Environment.SetEnvironmentVariable(name, "test");
-                        Assert.AreEqual("test", System.Environment.GetEnvironmentVariable(name));
+                        global::System.Environment.SetEnvironmentVariable(name, "test");
+                        Assert.AreEqual("test", global::System.Environment.GetEnvironmentVariable(name));
                     }
-                    Assert.AreEqual(null, System.Environment.GetEnvironmentVariable(name));
+                    Assert.AreEqual(null, global::System.Environment.GetEnvironmentVariable(name));
                 }));
             }
 
@@ -61,17 +61,17 @@ namespace bradselw.MachineStateManager.Persistence.Tests
         {
             var machineStateManager = new PersistentMachineStateManager();
             var name = "foo";
-            var previousValue = System.Environment.GetEnvironmentVariable(name);
+            var previousValue = global::System.Environment.GetEnvironmentVariable(name);
 
             using (machineStateManager.SnapshotEnvironmentVariable(name))
             using (machineStateManager.SnapshotEnvironmentVariable(name))
             {
                 var newValue = Guid.NewGuid().ToString();
-                System.Environment.SetEnvironmentVariable(name, newValue);
-                Assert.AreEqual(newValue, System.Environment.GetEnvironmentVariable(name));
+                global::System.Environment.SetEnvironmentVariable(name, newValue);
+                Assert.AreEqual(newValue, global::System.Environment.GetEnvironmentVariable(name));
             }
 
-            Assert.AreEqual(previousValue, System.Environment.GetEnvironmentVariable(name));
+            Assert.AreEqual(previousValue, global::System.Environment.GetEnvironmentVariable(name));
         }
     }
 }

--- a/MachineStateManager.Persistence/Environment/PersistentEnvironmentVariableOriginator.cs
+++ b/MachineStateManager.Persistence/Environment/PersistentEnvironmentVariableOriginator.cs
@@ -1,5 +1,5 @@
 ﻿using bradselw.MachineStateManager.Environment;
-using bradselw.SystemResources.Environment.Proxy;
+using bradselw.System.Resources.Environment;
 using LiteDB;
 using System;
 

--- a/MachineStateManager.Persistence/FileSystem/Caching/LiteDBBlobStore.cs
+++ b/MachineStateManager.Persistence/FileSystem/Caching/LiteDBBlobStore.cs
@@ -1,5 +1,5 @@
 ﻿using bradselw.MachineStateManager.FileSystem;
-using bradselw.SystemResources.FileSystem.Proxy;
+using bradselw.System.Resources.FileSystem;
 using LiteDB;
 using System;
 using System.IO;

--- a/MachineStateManager.Persistence/FileSystem/PersistentDirectoryOriginator.cs
+++ b/MachineStateManager.Persistence/FileSystem/PersistentDirectoryOriginator.cs
@@ -1,5 +1,5 @@
 ﻿using bradselw.MachineStateManager.FileSystem;
-using bradselw.SystemResources.FileSystem.Proxy;
+using bradselw.System.Resources.FileSystem;
 using LiteDB;
 
 namespace bradselw.MachineStateManager.Persistence.FileSystem

--- a/MachineStateManager.Persistence/FileSystem/PersistentFileOriginator.cs
+++ b/MachineStateManager.Persistence/FileSystem/PersistentFileOriginator.cs
@@ -1,5 +1,5 @@
 ﻿using bradselw.MachineStateManager.FileSystem;
-using bradselw.SystemResources.FileSystem.Proxy;
+using bradselw.System.Resources.FileSystem;
 using LiteDB;
 
 namespace bradselw.MachineStateManager.Persistence.FileSystem

--- a/MachineStateManager.Persistence/LiteDatabaseFactory.cs
+++ b/MachineStateManager.Persistence/LiteDatabaseFactory.cs
@@ -12,9 +12,14 @@ namespace bradselw.MachineStateManager.Persistence
     {
         public static LiteDatabase GetDatabase()
         {
-            var databaseDirectory = new DirectoryInfo(Path.Combine(
-                System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData),
-                nameof(MachineStateManager)));
+            if (!PersistentMachineStateManager.PersistenceURI.IsFile)
+            {
+                throw new NotSupportedException($"{nameof(PersistentMachineStateManager.PersistenceURI)} is invalid. Only local file paths are supported.");
+            }
+
+            var databaseFile = new FileInfo(PersistentMachineStateManager.PersistenceURI.LocalPath);
+
+            var databaseDirectory = databaseFile.Directory;
 
             if (!databaseDirectory.Exists)
             {
@@ -33,10 +38,6 @@ namespace bradselw.MachineStateManager.Persistence
                 }
             }
 
-            var databaseFilePath = Path.Combine(
-                databaseDirectory.FullName,
-                $"{nameof(Persistence)}.litedb");
-
             // LiteDB adheres to the BSON specification, and only stores DateTime values up to the milliseconds.
             // The following overrides the default behavior to store the exact DateTime, down to the tick.
             // For more information, see https://github.com/mbdavid/LiteDB/issues/1765.
@@ -46,7 +47,7 @@ namespace bradselw.MachineStateManager.Persistence
                 deserialize: bson => DateTime.ParseExact(bson, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
 
             return new LiteDatabase(
-                connectionString: new ConnectionString(databaseFilePath)
+                connectionString: new ConnectionString(databaseFile.FullName)
                 {
                     Connection = ConnectionType.Shared
                 },

--- a/MachineStateManager.Persistence/PersistentMachineStateManager.cs
+++ b/MachineStateManager.Persistence/PersistentMachineStateManager.cs
@@ -3,20 +3,27 @@ using bradselw.MachineStateManager.Persistence.Environment;
 using bradselw.MachineStateManager.Persistence.FileSystem;
 using bradselw.MachineStateManager.Persistence.FileSystem.Caching;
 using bradselw.MachineStateManager.Persistence.Registry;
-using bradselw.SystemResources.Environment.Proxy;
-using bradselw.SystemResources.FileSystem.Proxy;
-using bradselw.SystemResources.Registry.Proxy;
+using bradselw.System.Resources.Environment;
+using bradselw.System.Resources.FileSystem;
+using bradselw.System.Resources.Registry;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 
 namespace bradselw.MachineStateManager.Persistence
 {
     public class PersistentMachineStateManager : MachineStateManager
     {
+        public static Uri PersistenceURI { get; set; } = new Uri(
+            Path.Combine(
+                global::System.Environment.GetFolderPath(global::System.Environment.SpecialFolder.CommonApplicationData),
+                nameof(MachineStateManager),
+                $"{nameof(Persistence)}.litedb"));
+
         public PersistentMachineStateManager()
             : this(new DefaultEnvironmentProxy(), new DefaultFileSystemProxy(), new DefaultRegistryProxy())
         {
@@ -63,10 +70,9 @@ namespace bradselw.MachineStateManager.Persistence
         }
 
         /// <summary>
-        /// Gets abandoned caretakers on the current machine. An "abandoned caretaker" is a caretaker that was created by a process that no longer exists.
+        /// Restores abandoned snapshots on the current machine. An "abandoned snapshot" is a snapshot that was created by a process that no longer exists.
         /// </summary>
-        /// <returns>An enumeration of all caretakers on this machine that have been abandoned.</returns>
-        public static void RestoreAbandonedCaretakers()
+        public static void RestoreAbandonedSnapshots()
         {
             // Create a dictionary that maps process IDs to process start times, which will be used to uniquely identify a currently running process.
             // A null value indicates that this process does not have permission to the other process - try rerunning in an elevated process.

--- a/MachineStateManager.Persistence/Registry/PersistentRegistryKeyOriginator.cs
+++ b/MachineStateManager.Persistence/Registry/PersistentRegistryKeyOriginator.cs
@@ -1,5 +1,5 @@
 ﻿using bradselw.MachineStateManager.Registry;
-using bradselw.SystemResources.Registry.Proxy;
+using bradselw.System.Resources.Registry;
 using LiteDB;
 using Microsoft.Win32;
 

--- a/MachineStateManager.Persistence/Registry/PersistentRegistryValueOriginator.cs
+++ b/MachineStateManager.Persistence/Registry/PersistentRegistryValueOriginator.cs
@@ -1,5 +1,5 @@
 ﻿using bradselw.MachineStateManager.Registry;
-using bradselw.SystemResources.Registry.Proxy;
+using bradselw.System.Resources.Registry;
 using LiteDB;
 using Microsoft.Win32;
 

--- a/MachineStateManager.Persistence/version.json
+++ b/MachineStateManager.Persistence/version.json
@@ -1,7 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
     "pathFilters": [
-        "."
+        ".",
+        "../MachineStateManager"
     ],
     "inherit": true
 }

--- a/MachineStateManager.Tests/EnvironmentTests.cs
+++ b/MachineStateManager.Tests/EnvironmentTests.cs
@@ -10,16 +10,16 @@ namespace bradselw.MachineStateManager.Tests
         {
             var machineStateManager = new MachineStateManager();
             var name = "foo";
-            var previousValue = System.Environment.GetEnvironmentVariable(name);
+            var previousValue = global::System.Environment.GetEnvironmentVariable(name);
 
             using (machineStateManager.SnapshotEnvironmentVariable(name))
             {
                 var newValue = Guid.NewGuid().ToString();
-                System.Environment.SetEnvironmentVariable(name, newValue);
-                Assert.AreEqual(newValue, System.Environment.GetEnvironmentVariable(name));
+                global::System.Environment.SetEnvironmentVariable(name, newValue);
+                Assert.AreEqual(newValue, global::System.Environment.GetEnvironmentVariable(name));
             }
 
-            Assert.AreEqual(previousValue, System.Environment.GetEnvironmentVariable(name));
+            Assert.AreEqual(previousValue, global::System.Environment.GetEnvironmentVariable(name));
         }
     }
 }

--- a/MachineStateManager/Environment/EnvironmentVariableOriginator.cs
+++ b/MachineStateManager/Environment/EnvironmentVariableOriginator.cs
@@ -1,4 +1,4 @@
-﻿using bradselw.SystemResources.Environment.Proxy;
+﻿using bradselw.System.Resources.Environment;
 using System;
 
 namespace bradselw.MachineStateManager.Environment

--- a/MachineStateManager/FileSystem/Caching/LocalBlobStore.cs
+++ b/MachineStateManager/FileSystem/Caching/LocalBlobStore.cs
@@ -1,4 +1,4 @@
-﻿using bradselw.SystemResources.FileSystem.Proxy;
+﻿using bradselw.System.Resources.FileSystem;
 using System;
 using System.IO;
 

--- a/MachineStateManager/FileSystem/DirectoryOriginator.cs
+++ b/MachineStateManager/FileSystem/DirectoryOriginator.cs
@@ -1,4 +1,4 @@
-﻿using bradselw.SystemResources.FileSystem.Proxy;
+﻿using bradselw.System.Resources.FileSystem;
 using System;
 
 namespace bradselw.MachineStateManager.FileSystem
@@ -16,7 +16,7 @@ namespace bradselw.MachineStateManager.FileSystem
                 throw new ArgumentNullException(nameof(path));
             }
 
-            Path = System.IO.Path.GetFullPath(path);
+            Path = global::System.IO.Path.GetFullPath(path);
             FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
 

--- a/MachineStateManager/FileSystem/FileOriginator.cs
+++ b/MachineStateManager/FileSystem/FileOriginator.cs
@@ -1,4 +1,4 @@
-﻿using bradselw.SystemResources.FileSystem.Proxy;
+﻿using bradselw.System.Resources.FileSystem;
 using System;
 
 namespace bradselw.MachineStateManager.FileSystem
@@ -22,7 +22,7 @@ namespace bradselw.MachineStateManager.FileSystem
                 throw new ArgumentNullException(nameof(path));
             }
 
-            Path = System.IO.Path.GetFullPath(path);
+            Path = global::System.IO.Path.GetFullPath(path);
             FileCache = fileCache ?? throw new ArgumentNullException(nameof(fileCache));
             FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
         }
@@ -39,7 +39,7 @@ namespace bradselw.MachineStateManager.FileSystem
 
         public void SetState(FileMemento memento)
         {
-            var directoryPath = System.IO.Path.GetDirectoryName(Path);
+            var directoryPath = global::System.IO.Path.GetDirectoryName(Path);
             if (!FileSystem.DirectoryExists(directoryPath))
             {
                 FileSystem.CreateDirectory(directoryPath);

--- a/MachineStateManager/FileSystem/IBlobStore.cs
+++ b/MachineStateManager/FileSystem/IBlobStore.cs
@@ -1,4 +1,4 @@
-﻿using bradselw.SystemResources.FileSystem.Proxy;
+﻿using bradselw.System.Resources.FileSystem;
 
 namespace bradselw.MachineStateManager.FileSystem
 {

--- a/MachineStateManager/MachineStateManager.cs
+++ b/MachineStateManager/MachineStateManager.cs
@@ -2,9 +2,9 @@
 using bradselw.MachineStateManager.FileSystem;
 using bradselw.MachineStateManager.FileSystem.Caching;
 using bradselw.MachineStateManager.Registry;
-using bradselw.SystemResources.Environment.Proxy;
-using bradselw.SystemResources.FileSystem.Proxy;
-using bradselw.SystemResources.Registry.Proxy;
+using bradselw.System.Resources.Environment;
+using bradselw.System.Resources.FileSystem;
+using bradselw.System.Resources.Registry;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
@@ -34,7 +34,7 @@ namespace bradselw.MachineStateManager
         }
 
         public MachineStateManager(IEnvironmentProxy environment, IFileSystemProxy fileSystem, IRegistryProxy registry)
-            : this(new LocalBlobStore(Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), nameof(MachineStateManager), "FileCache"), fileSystem), environment, fileSystem, registry)
+            : this(new LocalBlobStore(Path.Combine(global::System.Environment.GetFolderPath(global::System.Environment.SpecialFolder.CommonApplicationData), nameof(MachineStateManager), "FileCache"), fileSystem), environment, fileSystem, registry)
         {
         }
 

--- a/MachineStateManager/MachineStateManager.csproj
+++ b/MachineStateManager/MachineStateManager.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="bradselw.SystemResources.Environment" Version="1.0.2" />
-    <PackageReference Include="bradselw.SystemResources.FileSystem" Version="1.0.4" />
-    <PackageReference Include="bradselw.SystemResources.Registry" Version="1.0.5" />
+    <PackageReference Include="bradselw.System.Resources.Environment" Version="1.0.4" />
+    <PackageReference Include="bradselw.System.Resources.FileSystem" Version="1.0.6" />
+    <PackageReference Include="bradselw.System.Resources.Registry" Version="1.0.7" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 

--- a/MachineStateManager/Registry/RegistryKeyOriginator.cs
+++ b/MachineStateManager/Registry/RegistryKeyOriginator.cs
@@ -1,4 +1,4 @@
-﻿using bradselw.SystemResources.Registry.Proxy;
+﻿using bradselw.System.Resources.Registry;
 using Microsoft.Win32;
 using System;
 

--- a/MachineStateManager/Registry/RegistryValueOriginator.cs
+++ b/MachineStateManager/Registry/RegistryValueOriginator.cs
@@ -1,4 +1,4 @@
-﻿using bradselw.SystemResources.Registry.Proxy;
+﻿using bradselw.System.Resources.Registry;
 using Microsoft.Win32;
 using System;
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # MachineStateManager
-Snapshot and restore the state of local machine resources.
+
+Snapshot and restore the state of local system resources.


### PR DESCRIPTION
Adding a static member `PersistenceURI` to `PersistentMachineStateManager` that allows callers to override the location of the persistence store.