### PR TITLE
Run tests during GitHub actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Test
       uses: microsoft/vstest-action@v1.0.0
       with:
-        searchFolder: D:\a\MachineStateManager\MachineStateManager\MachineStateManager.Persistence.Tests\bin\Release\net6.0
+        searchFolder: 'D:\a\MachineStateManager\MachineStateManager\MachineStateManager.Persistence.Tests\bin\Release\net6.0\'
         testAssembly: '*.Tests.dll'
 #     - name: Test
 #       run: dotnet test --configuration Release --no-build --verbosity normal


### PR DESCRIPTION
One of the tests uses MS fakes, which doesn't seem to be fully supported by `dotnet build` and `dotnet test` yet. This PR attempts to get build and test running.