### PR TITLE
Fix support for concurrent managers

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SystemStateManager.Persistence/Environment/PersistentEnvironmentVariableCaretaker.cs
+++ b/src/SystemStateManager.Persistence/Environment/PersistentEnvironmentVariableCaretaker.cs
@@ -8,17 +8,17 @@ namespace DevOptimal.SystemStateManager.Persistence.Environment
 {
     internal class PersistentEnvironmentVariableCaretaker : PersistentCaretaker<EnvironmentVariableOriginator, EnvironmentVariableMemento>
     {
-        public PersistentEnvironmentVariableCaretaker(string id, EnvironmentVariableOriginator originator, SqliteConnection connection)
-            : base(id, originator, connection)
+        public PersistentEnvironmentVariableCaretaker(string id, EnvironmentVariableOriginator originator)
+            : base(id, originator)
         {
         }
 
-        public PersistentEnvironmentVariableCaretaker(string id, long processID, DateTime processStartTime, EnvironmentVariableOriginator originator, EnvironmentVariableMemento memento, SqliteConnection connection)
-            : base(id, (int)processID, processStartTime, originator, memento, connection)
+        public PersistentEnvironmentVariableCaretaker(string id, long processID, DateTime processStartTime, EnvironmentVariableOriginator originator, EnvironmentVariableMemento memento)
+            : base(id, (int)processID, processStartTime, originator, memento)
         {
         }
 
-        protected override void Initialize()
+        protected override void Initialize(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -33,7 +33,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Environment
             command.ExecuteNonQuery();
         }
 
-        protected override void Persist()
+        protected override void Persist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -61,7 +61,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Environment
             command.ExecuteNonQuery();
         }
 
-        protected override void Unpersist()
+        protected override void Unpersist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText = $@"DELETE FROM {nameof(PersistentEnvironmentVariableCaretaker)} WHERE {nameof(ID)} = @{nameof(ID)};";
@@ -91,8 +91,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Environment
                             memento: new EnvironmentVariableMemento
                             {
                                 Value = reader.GetNullableString(nameof(EnvironmentVariableMemento.Value))
-                            },
-                            connection: connection
+                            }
                         );
                         caretakers.Add(caretaker);
                     }

--- a/src/SystemStateManager.Persistence/Extensions.cs
+++ b/src/SystemStateManager.Persistence/Extensions.cs
@@ -31,6 +31,8 @@ namespace DevOptimal.SystemStateManager.Persistence
             return reader.GetString(ordinal);
         }
 
+        public static Stream GetStream(this SqliteDataReader reader, string name) => reader.GetStream(reader.GetOrdinal(name));
+
         public static Stream GetNullableStream(this SqliteDataReader reader, string name) => reader.GetNullableStream(reader.GetOrdinal(name));
 
         public static Stream GetNullableStream(this SqliteDataReader reader, int ordinal)

--- a/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
+++ b/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
@@ -8,7 +8,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
 {
     internal class SQLiteFileCache : IFileCache
     {
-        private const int maxChunkSize = 1000000;
+        private const int maxChunkSize = 999999953; // Maximum BLOB size for SQLite database
 
         private class FileChunk
         {

--- a/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
+++ b/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
@@ -57,7 +57,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
                     {
                         while (reader.Read())
                         {
-                            using (var blobStream = reader.GetStream(reader.GetOrdinal(nameof(FileChunk.Data))))
+                            using (var blobStream = reader.GetStream(nameof(FileChunk.Data)))
                             {
                                 blobStream.CopyTo(fileStream);
                             }

--- a/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
+++ b/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
@@ -8,7 +8,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
 {
     internal class SQLiteFileCache : IFileCache
     {
-        private const int maxChunkSize = 10000;
+        private const int maxChunkSize = 1000000;
 
         private class FileChunk
         {

--- a/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
+++ b/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
@@ -1,6 +1,5 @@
 ﻿using DevOptimal.SystemStateManager.FileSystem;
 using DevOptimal.SystemUtilities.FileSystem;
-using Microsoft.Data.Sqlite;
 using System;
 using System.IO;
 
@@ -21,43 +20,55 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
 
         public IFileSystem FileSystem { get; }
 
-        private readonly SqliteConnection connection;
-
-        public SQLiteFileCache(IFileSystem fileSystem, SqliteConnection connection)
+        public SQLiteFileCache(IFileSystem fileSystem)
         {
             FileSystem = fileSystem;
-            this.connection = connection;
 
-            var createCommand = connection.CreateCommand();
-            createCommand.CommandText =
-            $@"CREATE TABLE IF NOT EXISTS {nameof(FileChunk)} (
-                {nameof(FileChunk.FileID)} INTEGER NOT NULL,
-                {nameof(FileChunk.ChunkIndex)} INTEGER NOT NULL,
-                {nameof(FileChunk.Data)} BLOB,
-                PRIMARY KEY ({nameof(FileChunk.FileID)}, {nameof(FileChunk.ChunkIndex)})
-            );";
-            createCommand.ExecuteNonQuery();
+            using (var connection = SqliteConnectionFactory.Create())
+            {
+                var createCommand = connection.CreateCommand();
+                createCommand.CommandText =
+                $@"CREATE TABLE IF NOT EXISTS {nameof(FileChunk)} (
+                    {nameof(FileChunk.FileID)} INTEGER NOT NULL,
+                    {nameof(FileChunk.ChunkIndex)} INTEGER NOT NULL,
+                    {nameof(FileChunk.Data)} BLOB,
+                    PRIMARY KEY ({nameof(FileChunk.FileID)}, {nameof(FileChunk.ChunkIndex)})
+                );";
+                createCommand.ExecuteNonQuery();
+            }
         }
 
         public void DownloadFile(string id, string destinationPath)
         {
             var destinationFile = new FileInfo(destinationPath);
             using (var fileStream = FileSystem.OpenFile(destinationFile.FullName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
+            using (var connection = SqliteConnectionFactory.Create())
+            using (var transaction = connection.BeginTransaction())
             {
-                fileStream.SetLength(0); // Delete existing file.
-
-                var selectCommand = connection.CreateCommand();
-                selectCommand.CommandText = $@"SELECT {nameof(FileChunk.Data)} FROM {nameof(FileChunk)} WHERE {nameof(FileChunk.FileID)} = @{nameof(FileChunk.FileID)} ORDER BY {nameof(FileChunk.ChunkIndex)} ASC";
-                selectCommand.Parameters.AddWithValue($"@{nameof(FileChunk.FileID)}", id);
-                using (var reader = selectCommand.ExecuteReader())
+                try
                 {
-                    while (reader.Read())
+                    fileStream.SetLength(0); // Delete existing file.
+
+                    var selectCommand = connection.CreateCommand();
+                    selectCommand.CommandText = $@"SELECT {nameof(FileChunk.Data)} FROM {nameof(FileChunk)} WHERE {nameof(FileChunk.FileID)} = @{nameof(FileChunk.FileID)} ORDER BY {nameof(FileChunk.ChunkIndex)} ASC";
+                    selectCommand.Parameters.AddWithValue($"@{nameof(FileChunk.FileID)}", id);
+                    using (var reader = selectCommand.ExecuteReader())
                     {
-                        using (var blobStream = reader.GetStream(nameof(FileChunk.Data)))
+                        while (reader.Read())
                         {
-                            blobStream.CopyTo(fileStream);
+                            using (var blobStream = reader.GetStream(nameof(FileChunk.Data)))
+                            {
+                                blobStream.CopyTo(fileStream);
+                            }
                         }
                     }
+
+                    transaction.Commit();
+                }
+                catch
+                {
+                    transaction.Rollback();
+                    throw;
                 }
             }
         }
@@ -68,18 +79,22 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
             var file = new FileInfo(sourcePath);
 
             using (var fileStream = FileSystem.OpenFile(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var connection = SqliteConnectionFactory.Create())
+            using (var transaction = connection.BeginTransaction())
             {
-                var index = 0;
-                var remainingBytes = fileStream.Length;
-                while (remainingBytes > 0)
+                try
                 {
-                    var bufferSize = (int)Math.Min(maxChunkSize, remainingBytes);
-                    var buffer = new byte[bufferSize];
-                    remainingBytes -= fileStream.Read(buffer, 0, bufferSize);
+                    var index = 0;
+                    var remainingBytes = fileStream.Length;
+                    while (remainingBytes > 0)
+                    {
+                        var bufferSize = (int)Math.Min(maxChunkSize, remainingBytes);
+                        var buffer = new byte[bufferSize];
+                        remainingBytes -= fileStream.Read(buffer, 0, bufferSize);
 
-                    var command = connection.CreateCommand();
-                    command.CommandText =
-                    $@"INSERT INTO {nameof(FileChunk)} (
+                        var command = connection.CreateCommand();
+                        command.CommandText =
+                        $@"INSERT INTO {nameof(FileChunk)} (
                         {nameof(FileChunk.FileID)},
                         {nameof(FileChunk.ChunkIndex)},
                         {nameof(FileChunk.Data)}
@@ -88,10 +103,18 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
                         @{nameof(FileChunk.ChunkIndex)},
                         @{nameof(FileChunk.Data)}
                     );";
-                    command.Parameters.AddWithValue($"@{nameof(FileChunk.FileID)}", fileID);
-                    command.Parameters.AddWithValue($"@{nameof(FileChunk.ChunkIndex)}", index++);
-                    command.Parameters.AddWithValue($"@{nameof(FileChunk.Data)}", buffer);
-                    command.ExecuteNonQuery();
+                        command.Parameters.AddWithValue($"@{nameof(FileChunk.FileID)}", fileID);
+                        command.Parameters.AddWithValue($"@{nameof(FileChunk.ChunkIndex)}", index++);
+                        command.Parameters.AddWithValue($"@{nameof(FileChunk.Data)}", buffer);
+                        command.ExecuteNonQuery();
+                    }
+
+                    transaction.Commit();
+                }
+                catch
+                {
+                    transaction.Rollback();
+                    throw;
                 }
             }
 

--- a/src/SystemStateManager.Persistence/FileSystem/PersistentDirectoryCaretaker.cs
+++ b/src/SystemStateManager.Persistence/FileSystem/PersistentDirectoryCaretaker.cs
@@ -8,18 +8,18 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
 {
     internal class PersistentDirectoryCaretaker : PersistentCaretaker<DirectoryOriginator, DirectoryMemento>
     {
-        public PersistentDirectoryCaretaker(string id, DirectoryOriginator originator, SqliteConnection connection)
-            : base(id, originator, connection)
+        public PersistentDirectoryCaretaker(string id, DirectoryOriginator originator)
+            : base(id, originator)
         {
         }
 
-        public PersistentDirectoryCaretaker(string id, int processID, DateTime processStartTime, DirectoryOriginator originator, DirectoryMemento memento, SqliteConnection connection)
-            : base(id, processID, processStartTime, originator, memento, connection)
+        public PersistentDirectoryCaretaker(string id, int processID, DateTime processStartTime, DirectoryOriginator originator, DirectoryMemento memento)
+            : base(id, processID, processStartTime, originator, memento)
         {
         }
 
 
-        protected override void Initialize()
+        protected override void Initialize(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -33,7 +33,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
             command.ExecuteNonQuery();
         }
 
-        protected override void Persist()
+        protected override void Persist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -58,7 +58,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
             command.ExecuteNonQuery();
         }
 
-        protected override void Unpersist()
+        protected override void Unpersist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText = $@"DELETE FROM {nameof(PersistentDirectoryCaretaker)} WHERE {nameof(ID)} = @{nameof(ID)};";
@@ -87,8 +87,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
                             memento: new DirectoryMemento
                             {
                                 Exists = reader.GetBoolean(nameof(DirectoryMemento.Exists))
-                            },
-                            connection: connection
+                            }
                         );
                         caretakers.Add(caretaker);
                     }

--- a/src/SystemStateManager.Persistence/FileSystem/PersistentFileCaretaker.cs
+++ b/src/SystemStateManager.Persistence/FileSystem/PersistentFileCaretaker.cs
@@ -8,18 +8,18 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
 {
     internal class PersistentFileCaretaker : PersistentCaretaker<FileOriginator, FileMemento>
     {
-        public PersistentFileCaretaker(string id, FileOriginator originator, SqliteConnection connection)
-            : base(id, originator, connection)
+        public PersistentFileCaretaker(string id, FileOriginator originator)
+            : base(id, originator)
         {
         }
 
-        public PersistentFileCaretaker(string id, int processID, DateTime processStartTime, FileOriginator originator, FileMemento memento, SqliteConnection connection)
-            : base(id, processID, processStartTime, originator, memento, connection)
+        public PersistentFileCaretaker(string id, int processID, DateTime processStartTime, FileOriginator originator, FileMemento memento)
+            : base(id, processID, processStartTime, originator, memento)
         {
         }
 
 
-        protected override void Initialize()
+        protected override void Initialize(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -33,7 +33,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
             command.ExecuteNonQuery();
         }
 
-        protected override void Persist()
+        protected override void Persist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -58,7 +58,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
             command.ExecuteNonQuery();
         }
 
-        protected override void Unpersist()
+        protected override void Unpersist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText = $@"DELETE FROM {nameof(PersistentFileCaretaker)} WHERE {nameof(ID)} = @{nameof(ID)};";
@@ -88,8 +88,7 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem
                             memento: new FileMemento
                             {
                                 Hash = reader.GetNullableString(nameof(FileMemento.Hash))
-                            },
-                            connection: connection
+                            }
                         );
                         caretakers.Add(caretaker);
                     }

--- a/src/SystemStateManager.Persistence/PersistentCaretaker.cs
+++ b/src/SystemStateManager.Persistence/PersistentCaretaker.cs
@@ -26,7 +26,7 @@ namespace DevOptimal.SystemStateManager.Persistence
             ProcessID = currentProcess.Id;
             ProcessStartTime = currentProcess.StartTime;
 
-            using (var connection = SqliteConnectionFactory.Create()) // Sqlite connections are not thread safe: https://github.com/dotnet/efcore/issues/22664#issuecomment-696870423
+            using (var connection = SqliteConnectionFactory.Create())
             {
                 using (var transaction = connection.BeginTransaction())
                 {

--- a/src/SystemStateManager.Persistence/PersistentSystemStateManager.cs
+++ b/src/SystemStateManager.Persistence/PersistentSystemStateManager.cs
@@ -171,12 +171,12 @@ namespace DevOptimal.SystemStateManager.Persistence
             connection.Open();
 
             // Enable write-ahead logging
-            var walCommand = connection.CreateCommand();
-            walCommand.CommandText =
+            var command = connection.CreateCommand();
+            command.CommandText =
             @"
                 PRAGMA journal_mode = 'wal'
             ";
-            walCommand.ExecuteNonQuery();
+            command.ExecuteNonQuery();
 
             return connection;
         }

--- a/src/SystemStateManager.Persistence/PersistentSystemStateManager.cs
+++ b/src/SystemStateManager.Persistence/PersistentSystemStateManager.cs
@@ -164,10 +164,19 @@ namespace DevOptimal.SystemStateManager.Persistence
             {
                 DataSource = databaseFile.FullName,
                 Cache = SqliteCacheMode.Shared,
-                Mode = SqliteOpenMode.ReadWriteCreate
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = false
             }.ToString();
             var connection = new SqliteConnection(connectionString);
             connection.Open();
+
+            // Enable write-ahead logging
+            var walCommand = connection.CreateCommand();
+            walCommand.CommandText =
+            @"
+                PRAGMA journal_mode = 'wal'
+            ";
+            walCommand.ExecuteNonQuery();
 
             return connection;
         }

--- a/src/SystemStateManager.Persistence/PersistentSystemStateManager.cs
+++ b/src/SystemStateManager.Persistence/PersistentSystemStateManager.cs
@@ -8,7 +8,6 @@ using DevOptimal.SystemStateManager.Registry;
 using DevOptimal.SystemUtilities.Environment;
 using DevOptimal.SystemUtilities.FileSystem;
 using DevOptimal.SystemUtilities.Registry;
-using Microsoft.Data.Sqlite;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
@@ -16,21 +15,24 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Security.AccessControl;
-using System.Security.Principal;
 
 namespace DevOptimal.SystemStateManager.Persistence
 {
     public class PersistentSystemStateManager : SystemStateManager
     {
-        public static Uri PersistenceURI { get; set; } = new Uri(
-            Path.Combine(
-                System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData),
-                nameof(SystemStateManager),
-                $"{nameof(Persistence)}.db"));
+        public static Uri PersistenceURI
+        {
+            get => new Uri(SqliteConnectionFactory.DatabaseFile.FullName);
+            set
+            {
+                if (!value.IsFile)
+                {
+                    throw new NotSupportedException($"{nameof(PersistenceURI)} is invalid. Only local file paths are supported.");
+                }
 
-        private readonly SqliteConnection connection;
+                SqliteConnectionFactory.DatabaseFile = new FileInfo(value.LocalPath);
+            }
+        }
 
         public PersistentSystemStateManager()
             : this(new DefaultEnvironment(), new DefaultFileSystem(), new DefaultRegistry())
@@ -38,50 +40,43 @@ namespace DevOptimal.SystemStateManager.Persistence
         }
 
         public PersistentSystemStateManager(IEnvironment environment, IFileSystem fileSystem, IRegistry registry)
-            : this(environment, fileSystem, registry, CreateConnection())
+            : base(new SQLiteFileCache(fileSystem), environment, fileSystem, registry)
         {
         }
 
-        private PersistentSystemStateManager(IEnvironment environment, IFileSystem fileSystem, IRegistry registry, SqliteConnection connection)
-            : base(new SQLiteFileCache(fileSystem, connection), environment, fileSystem, registry)
-        {
-            this.connection = connection;
-        }
-
-        private PersistentSystemStateManager(List<ISnapshot> snapshots, IFileCache fileCache, IEnvironment environment, IFileSystem fileSystem, IRegistry registry, SqliteConnection connection)
+        private PersistentSystemStateManager(List<ISnapshot> snapshots, IFileCache fileCache, IEnvironment environment, IFileSystem fileSystem, IRegistry registry)
             : base(snapshots, fileCache, environment, fileSystem, registry)
         {
-            this.connection = connection;
         }
 
         protected override ISnapshot CreateEnvironmentVariableSnapshot(string id, string name, EnvironmentVariableTarget target, IEnvironment environment)
         {
             var originator = new EnvironmentVariableOriginator(name, target, environment);
-            return new PersistentEnvironmentVariableCaretaker(id, originator, connection);
+            return new PersistentEnvironmentVariableCaretaker(id, originator);
         }
 
         protected override ISnapshot CreateDirectorySnapshot(string id, string path, IFileSystem fileSystem)
         {
             var originator = new DirectoryOriginator(path, fileSystem);
-            return new PersistentDirectoryCaretaker(id, originator, connection);
+            return new PersistentDirectoryCaretaker(id, originator);
         }
 
         protected override ISnapshot CreateFileSnapshot(string id, string path, IFileCache fileCache, IFileSystem fileSystem)
         {
             var originator = new FileOriginator(path, fileCache, fileSystem);
-            return new PersistentFileCaretaker(id, originator, connection);
+            return new PersistentFileCaretaker(id, originator);
         }
 
         protected override ISnapshot CreateRegistryKeySnapshot(string id, RegistryHive hive, RegistryView view, string subKey, IRegistry registry)
         {
             var originator = new RegistryKeyOriginator(hive, view, subKey, registry);
-            return new PersistentRegistryKeyCaretaker(id, originator, connection);
+            return new PersistentRegistryKeyCaretaker(id, originator);
         }
 
         protected override ISnapshot CreateRegistryValueSnapshot(string id, RegistryHive hive, RegistryView view, string subKey, string name, IRegistry registry)
         {
             var originator = new RegistryValueOriginator(hive, view, subKey, name, registry);
-            return new PersistentRegistryValueCaretaker(id, originator, connection);
+            return new PersistentRegistryValueCaretaker(id, originator);
         }
 
         /// <summary>
@@ -113,8 +108,8 @@ namespace DevOptimal.SystemStateManager.Persistence
                 catch (InvalidOperationException) { } // The process has already exited, so don't add it.
             }
 
-            var connection = CreateConnection();
-            var fileCache = new SQLiteFileCache(fileSystem, connection);
+            var connection = SqliteConnectionFactory.Create();
+            var fileCache = new SQLiteFileCache(fileSystem);
 
             var allSnapshots = PersistentEnvironmentVariableCaretaker.GetCaretakers(connection, environment)
                 .Concat(PersistentDirectoryCaretaker.GetCaretakers(connection, fileSystem))
@@ -127,64 +122,9 @@ namespace DevOptimal.SystemStateManager.Persistence
 
             if (abandonedSnapshots.Any())
             {
-                var systemStateManager = new PersistentSystemStateManager(abandonedSnapshots, fileCache, environment, fileSystem, registry, connection);
+                var systemStateManager = new PersistentSystemStateManager(abandonedSnapshots, fileCache, environment, fileSystem, registry);
                 systemStateManager.Dispose();
             }
-        }
-
-        private static SqliteConnection CreateConnection()
-        {
-            if (!PersistenceURI.IsFile)
-            {
-                throw new NotSupportedException($"{nameof(PersistenceURI)} is invalid. Only local file paths are supported.");
-            }
-
-            var databaseFile = new FileInfo(PersistenceURI.LocalPath);
-
-            var databaseDirectory = databaseFile.Directory;
-
-            if (!databaseDirectory.Exists)
-            {
-                databaseDirectory.Create();
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    var directorySecurity = databaseDirectory.GetAccessControl();
-                    directorySecurity.AddAccessRule(new FileSystemAccessRule(
-                        identity: new SecurityIdentifier(WellKnownSidType.WorldSid, domainSid: null),
-                        fileSystemRights: FileSystemRights.FullControl,
-                        inheritanceFlags: InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
-                        propagationFlags: PropagationFlags.NoPropagateInherit,
-                        type: AccessControlType.Allow));
-                    databaseDirectory.SetAccessControl(directorySecurity);
-                }
-            }
-
-            var connectionString = new SqliteConnectionStringBuilder
-            {
-                DataSource = databaseFile.FullName,
-                Cache = SqliteCacheMode.Shared,
-                Mode = SqliteOpenMode.ReadWriteCreate,
-                Pooling = false
-            }.ToString();
-            var connection = new SqliteConnection(connectionString);
-            connection.Open();
-
-            // Enable write-ahead logging
-            var command = connection.CreateCommand();
-            command.CommandText =
-            @"
-                PRAGMA journal_mode = 'wal'
-            ";
-            command.ExecuteNonQuery();
-
-            return connection;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            connection.Dispose();
         }
     }
 }

--- a/src/SystemStateManager.Persistence/Registry/PersistentRegistryKeyCaretaker.cs
+++ b/src/SystemStateManager.Persistence/Registry/PersistentRegistryKeyCaretaker.cs
@@ -9,18 +9,18 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
 {
     internal class PersistentRegistryKeyCaretaker : PersistentCaretaker<RegistryKeyOriginator, RegistryKeyMemento>
     {
-        public PersistentRegistryKeyCaretaker(string id, RegistryKeyOriginator originator, SqliteConnection connection)
-            : base(id, originator, connection)
+        public PersistentRegistryKeyCaretaker(string id, RegistryKeyOriginator originator)
+            : base(id, originator)
         {
         }
 
-        public PersistentRegistryKeyCaretaker(string id, int processID, DateTime processStartTime, RegistryKeyOriginator originator, RegistryKeyMemento memento, SqliteConnection connection)
-            : base(id, processID, processStartTime, originator, memento, connection)
+        public PersistentRegistryKeyCaretaker(string id, int processID, DateTime processStartTime, RegistryKeyOriginator originator, RegistryKeyMemento memento)
+            : base(id, processID, processStartTime, originator, memento)
         {
         }
 
 
-        protected override void Initialize()
+        protected override void Initialize(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -36,7 +36,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
             command.ExecuteNonQuery();
         }
 
-        protected override void Persist()
+        protected override void Persist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -67,7 +67,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
             command.ExecuteNonQuery();
         }
 
-        protected override void Unpersist()
+        protected override void Unpersist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText = $@"DELETE FROM {nameof(PersistentRegistryKeyCaretaker)} WHERE {nameof(ID)} = @{nameof(ID)};";
@@ -98,8 +98,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
                             memento: new RegistryKeyMemento
                             {
                                 Exists = reader.GetBoolean(nameof(RegistryKeyMemento.Exists))
-                            },
-                            connection: connection
+                            }
                         );
                         caretakers.Add(caretaker);
                     }

--- a/src/SystemStateManager.Persistence/Registry/PersistentRegistryValueCaretaker.cs
+++ b/src/SystemStateManager.Persistence/Registry/PersistentRegistryValueCaretaker.cs
@@ -12,18 +12,18 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
 {
     internal class PersistentRegistryValueCaretaker : PersistentCaretaker<RegistryValueOriginator, RegistryValueMemento>
     {
-        public PersistentRegistryValueCaretaker(string id, RegistryValueOriginator originator, SqliteConnection connection)
-            : base(id, originator, connection)
+        public PersistentRegistryValueCaretaker(string id, RegistryValueOriginator originator)
+            : base(id, originator)
         {
         }
 
-        public PersistentRegistryValueCaretaker(string id, int processID, DateTime processStartTime, RegistryValueOriginator originator, RegistryValueMemento memento, SqliteConnection connection)
-            : base(id, processID, processStartTime, originator, memento, connection)
+        public PersistentRegistryValueCaretaker(string id, int processID, DateTime processStartTime, RegistryValueOriginator originator, RegistryValueMemento memento)
+            : base(id, processID, processStartTime, originator, memento)
         {
         }
 
 
-        protected override void Initialize()
+        protected override void Initialize(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -41,7 +41,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
             command.ExecuteNonQuery();
         }
 
-        protected override void Persist()
+        protected override void Persist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText =
@@ -78,7 +78,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
             command.ExecuteNonQuery();
         }
 
-        protected override void Unpersist()
+        protected override void Unpersist(SqliteConnection connection)
         {
             var command = connection.CreateCommand();
             command.CommandText = $@"DELETE FROM {nameof(PersistentRegistryValueCaretaker)} WHERE {nameof(ID)} = @{nameof(ID)};";
@@ -127,8 +127,7 @@ namespace DevOptimal.SystemStateManager.Persistence.Registry
                             {
                                 Value = ConvertBytesToValue(valueBytes),
                                 Kind = (RegistryValueKind)reader.GetInt32(nameof(RegistryValueMemento.Kind))
-                            },
-                            connection: connection
+                            }
                         );
                         caretakers.Add(caretaker);
                     }

--- a/src/SystemStateManager.Persistence/SqliteConnectionFactory.cs
+++ b/src/SystemStateManager.Persistence/SqliteConnectionFactory.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Data.Sqlite;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace DevOptimal.SystemStateManager.Persistence
+{
+    internal static class SqliteConnectionFactory
+    {
+        public static FileInfo DatabaseFile { get; set; } = new FileInfo(
+            Path.Combine(
+                System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData),
+                nameof(SystemStateManager),
+                $"{nameof(Persistence)}.db"));
+
+        public static SqliteConnection Create()
+        {
+            var databaseDirectory = DatabaseFile.Directory;
+
+            if (!databaseDirectory.Exists)
+            {
+                databaseDirectory.Create();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    var directorySecurity = databaseDirectory.GetAccessControl();
+                    directorySecurity.AddAccessRule(new FileSystemAccessRule(
+                        identity: new SecurityIdentifier(WellKnownSidType.WorldSid, domainSid: null),
+                        fileSystemRights: FileSystemRights.FullControl,
+                        inheritanceFlags: InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                        propagationFlags: PropagationFlags.NoPropagateInherit,
+                        type: AccessControlType.Allow));
+                    databaseDirectory.SetAccessControl(directorySecurity);
+                }
+            }
+
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = DatabaseFile.FullName,
+            }.ToString();
+            var connection = new SqliteConnection(connectionString);
+            connection.Open();
+
+            // Enable write-ahead logging
+            var command = connection.CreateCommand();
+            command.CommandText =
+            @"
+                PRAGMA journal_mode = 'wal'
+            ";
+            command.ExecuteNonQuery();
+
+            return connection;
+        }
+    }
+}

--- a/src/SystemStateManager.Persistence/SystemStateManager.Persistence.csproj
+++ b/src/SystemStateManager.Persistence/SystemStateManager.Persistence.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.5" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 

--- a/test/SystemStateManager.Persistence.Tests/PersistentSystemStateManagerTests.cs
+++ b/test/SystemStateManager.Persistence.Tests/PersistentSystemStateManagerTests.cs
@@ -1,6 +1,7 @@
-﻿using DevOptimal.SystemStateManager.Persistence;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace DevOptimal.SystemStateManager.Persistence.Tests
@@ -50,6 +51,78 @@ namespace DevOptimal.SystemStateManager.Persistence.Tests
             }
 
             Task.WaitAll(tasks.ToArray());
+        }
+
+        [TestMethod]
+        public void ConcurrentManagersCanSnapshotEnvironmentVariables()
+        {
+            var concurrentThreads = 100;
+
+            var names = new string[concurrentThreads];
+            var expectedValues = new string[concurrentThreads];
+            var target = EnvironmentVariableTarget.Machine;
+
+            for (var i = 0; i < concurrentThreads; i++)
+            {
+                var name = $"variable{i}";
+                var value = Guid.NewGuid().ToString();
+                environment.SetEnvironmentVariable(name, value, target);
+                names[i] = name;
+                expectedValues[i] = value;
+            }
+
+            Parallel.For(0, concurrentThreads, i =>
+            {
+                var name = names[i];
+                var value = expectedValues[i];
+                using var manager = CreatePersistentSystemStateManager();
+                var caretaker = manager.SnapshotEnvironmentVariable(name, target);
+
+                environment.SetEnvironmentVariable(name, null, target);
+                Assert.AreEqual(null, environment.GetEnvironmentVariable(name, target));
+
+                caretaker.Dispose();
+                Assert.AreEqual(expectedValues[i], environment.GetEnvironmentVariable(name, target));
+            });
+        }
+
+        [TestMethod]
+        public void ConcurrentManagersCanSnapshotFiles()
+        {
+            var concurrentThreads = 100;
+
+            var filePaths = new string[concurrentThreads];
+            var expectedContent = new byte[concurrentThreads][];
+
+            for (var i = 0; i < concurrentThreads; i++)
+            {
+                var file = $@"C:\file{i}.txt";
+                fileSystem.CreateFile(file);
+                filePaths[i] = file;
+
+                var content = Guid.NewGuid().ToByteArray();
+                using var stream = fileSystem.OpenFile(file, FileMode.Open, FileAccess.Write, FileShare.None);
+                stream.Write(content, 0, content.Length);
+                expectedContent[i] = content;
+            }
+
+            Parallel.For(0, concurrentThreads, i =>
+            {
+                var file = filePaths[i];
+                using var manager = CreatePersistentSystemStateManager();
+                var caretaker = manager.SnapshotFile(file);
+
+                fileSystem.DeleteFile(file);
+                Assert.IsFalse(fileSystem.FileExists(file));
+
+                caretaker.Dispose();
+                Assert.IsTrue(fileSystem.FileExists(file));
+                var content = expectedContent[i];
+                using var stream = fileSystem.OpenFile(file, FileMode.Open, FileAccess.Read, FileShare.None);
+                var readContent = new byte[content.Length];
+                stream.Read(readContent, 0, readContent.Length);
+                Assert.IsTrue(readContent.SequenceEqual(content));
+            });
         }
 
         [TestMethod]

--- a/test/SystemStateManager.Persistence.Tests/RestoreAbandonedSnapshotsTests.cs
+++ b/test/SystemStateManager.Persistence.Tests/RestoreAbandonedSnapshotsTests.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace DevOptimal.SystemStateManager.Persistence.Tests
 {
     [TestClass]
-    [TestCategory("OmitFromCI")] // Fakes require Visual Studio Enterprise, but agent machines only have Community installed.
+    //[TestCategory("OmitFromCI")] // Fakes require Visual Studio Enterprise, but agent machines only have Community installed.
     public class RestoreAbandonedSnapshotsTests : TestBase
     {
         [TestMethod]

--- a/test/SystemStateManager.Persistence.Tests/RestoreAbandonedSnapshotsTests.cs
+++ b/test/SystemStateManager.Persistence.Tests/RestoreAbandonedSnapshotsTests.cs
@@ -1,5 +1,4 @@
-﻿using DevOptimal.SystemStateManager.Persistence;
-using Microsoft.Win32;
+﻿using Microsoft.Win32;
 using System;
 using System.IO;
 using System.Runtime.Versioning;
@@ -8,7 +7,7 @@ using System.Text;
 namespace DevOptimal.SystemStateManager.Persistence.Tests
 {
     [TestClass]
-    //[TestCategory("OmitFromCI")] // Fakes require Visual Studio Enterprise, but agent machines only have Community installed.
+    [TestCategory("OmitFromCI")] // Fakes require Visual Studio Enterprise, but agent machines only have Community installed.
     public class RestoreAbandonedSnapshotsTests : TestBase
     {
         [TestMethod]

--- a/test/SystemStateManager.Persistence.Tests/TestBase.cs
+++ b/test/SystemStateManager.Persistence.Tests/TestBase.cs
@@ -1,5 +1,4 @@
-﻿using DevOptimal.SystemStateManager.Persistence;
-using DevOptimal.SystemUtilities.Environment;
+﻿using DevOptimal.SystemUtilities.Environment;
 using DevOptimal.SystemUtilities.FileSystem;
 using DevOptimal.SystemUtilities.Registry;
 using Microsoft.QualityTools.Testing.Fakes;


### PR DESCRIPTION
#16 switched the persistence layer to SQLite, but unfortunately introduced a regression where concurrent `PersistentSystemStateManagers` would fail with a "database is locked" error.

This PR addresses this problem by doing the following:
1. Enabling write-ahead logging on the SQLite database
2. Creating a new `SqliteConnection` for each call/transaction instead of sharing the same connection across all threads
3. Disabling shared caching