### PR TITLE
Fix issues #1 and #18

### DIFF
--- a/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
+++ b/src/SystemStateManager.Persistence/FileSystem/Caching/SQLiteFileCache.cs
@@ -48,8 +48,10 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
             {
                 try
                 {
-                    fileStream.SetLength(0); // Delete existing file.
+                    // Delete existing file
+                    fileStream.SetLength(0);
 
+                    // Download the file content
                     var selectCommand = connection.CreateCommand();
                     selectCommand.CommandText = $@"SELECT {nameof(FileChunk.Data)} FROM {nameof(FileChunk)} WHERE {nameof(FileChunk.FileID)} = @{nameof(FileChunk.FileID)} ORDER BY {nameof(FileChunk.ChunkIndex)} ASC";
                     selectCommand.Parameters.AddWithValue($"@{nameof(FileChunk.FileID)}", id);
@@ -63,6 +65,12 @@ namespace DevOptimal.SystemStateManager.Persistence.FileSystem.Caching
                             }
                         }
                     }
+
+                    // Delete the file content from the cache
+                    var deleteCommand = connection.CreateCommand();
+                    deleteCommand.CommandText = $@"DELETE FROM {nameof(FileChunk)} WHERE {nameof(FileChunk.FileID)} = @{nameof(FileChunk.FileID)};";
+                    deleteCommand.Parameters.AddWithValue($"@{nameof(FileChunk.FileID)}", id);
+                    deleteCommand.ExecuteNonQuery();
 
                     transaction.Commit();
                 }

--- a/test/SystemStateManager.Persistence.Tests/PersistentSystemStateManagerTests.cs
+++ b/test/SystemStateManager.Persistence.Tests/PersistentSystemStateManagerTests.cs
@@ -76,12 +76,12 @@ namespace DevOptimal.SystemStateManager.Persistence.Tests
                 var name = names[i];
                 var value = expectedValues[i];
                 using var manager = CreatePersistentSystemStateManager();
-                var caretaker = manager.SnapshotEnvironmentVariable(name, target);
+                using (var caretaker = manager.SnapshotEnvironmentVariable(name, target))
+                {
+                    environment.SetEnvironmentVariable(name, null, target);
+                    Assert.AreEqual(null, environment.GetEnvironmentVariable(name, target));
+                }
 
-                environment.SetEnvironmentVariable(name, null, target);
-                Assert.AreEqual(null, environment.GetEnvironmentVariable(name, target));
-
-                caretaker.Dispose();
                 Assert.AreEqual(expectedValues[i], environment.GetEnvironmentVariable(name, target));
             });
         }
@@ -110,12 +110,12 @@ namespace DevOptimal.SystemStateManager.Persistence.Tests
             {
                 var file = filePaths[i];
                 using var manager = CreatePersistentSystemStateManager();
-                var caretaker = manager.SnapshotFile(file);
+                using (var caretaker = manager.SnapshotFile(file))
+                {
+                    fileSystem.DeleteFile(file);
+                    Assert.IsFalse(fileSystem.FileExists(file));
+                }
 
-                fileSystem.DeleteFile(file);
-                Assert.IsFalse(fileSystem.FileExists(file));
-
-                caretaker.Dispose();
                 Assert.IsTrue(fileSystem.FileExists(file));
                 var content = expectedContent[i];
                 using var stream = fileSystem.OpenFile(file, FileMode.Open, FileAccess.Read, FileShare.None);


### PR DESCRIPTION
Issue #1 relates to the scope of the persistence layer. The persistence layer existing to allow callers to restore state that was not properly cleaned up by other processes (e.g. in the case of a process crash). This means that the persistence layer should only concern itself with machine state _outside_ of the current process. Environment variables can target the entire machine, the current user, or the current process. Obviously, we should not persist process environment variables because that would lead to the process restoring the abandoned snapshots getting set with an environment variable that was scoped to the process that abandoned the snapshot. This PR addresses this by ensuring that the persistence layer only persists environment variable snapshots that target either the machine or the current user.

Issue #18 involves the `SQLiteFileCache`, which is used to persist the content of files that are snapshotted. Each time a file snapshot is taken, the file's content gets uploaded to the database. Whenever the snapshot is restored, the file's content gets downloaded form the database, overwriting whatever content was in the file. Each time a new file snapshot is taken and its content uploaded, that causes the database to grow in size. Unfortunately, the `SQLiteFileCache` is currently doing nothing to clean up old content, meaning that the database continues to grow with each snapshot, never decreasing in size. This PR addresses this issue by deleting the file content when it is downloaded.